### PR TITLE
feat: deploy tvcentras as wgmesh origin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,10 @@
 name: Deploy TV Dashboard
 
 # Builds the Docker image on every push to main, pushes to ghcr.io,
-# then deploys to the Hetzner VPS alongside the existing Coroot stack.
+# then deploys to the tvcentras origin server (joined to wgmesh; edges
+# serve tv.beerpub.dev over TLS via WireGuard tunnel).
+#
+# One-time infra setup is handled by provision.yml.
 
 on:
   push:
@@ -11,7 +14,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  SSH_KEY_PATH: /tmp/vps_ssh_key
+  SSH_KEY_PATH: /tmp/tvcentras_ssh
+  SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 jobs:
   build-push:
@@ -61,123 +65,49 @@ jobs:
           echo "| digest | \`${{ steps.push.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
 
   deploy:
-    name: Deploy to VPS
+    name: Deploy to origin
     needs: build-push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup SSH
+      - name: Setup SSH key
         run: |
-          echo "${{ secrets.VPS_SSH_KEY }}" > ${{ env.SSH_KEY_PATH }}
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.CHIMNEY_SSH_KEY }}" > ${{ env.SSH_KEY_PATH }}
           chmod 600 ${{ env.SSH_KEY_PATH }}
-          mkdir -p ~/.ssh
-          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
 
-      - name: Upload compose file
+      - name: Pull & restart on origin
         run: |
-          ssh -i ${{ env.SSH_KEY_PATH }} -o StrictHostKeyChecking=no \
-            root@${{ secrets.VPS_HOST }} 'mkdir -p /opt/tvcentras'
-          scp -i ${{ env.SSH_KEY_PATH }} -o StrictHostKeyChecking=no \
-            deploy/docker-compose.yml \
-            root@${{ secrets.VPS_HOST }}:/opt/tvcentras/docker-compose.yml
+          IP="${{ secrets.TVCENTRAS_ORIGIN_IP }}"
+          SSH="ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} root@$IP"
 
-      - name: Pull & restart
-        run: |
-          ssh -i ${{ env.SSH_KEY_PATH }} -o StrictHostKeyChecking=no \
-            root@${{ secrets.VPS_HOST }} '
-              set -e
-              cd /opt/tvcentras
-              docker compose pull tvcentras
-              docker compose up -d tvcentras
-              echo "=== Container status ==="
-              docker compose ps tvcentras
-            '
+          $SSH '
+            set -e
+            cd /opt/tvcentras
+            docker compose pull tvcentras
+            docker compose up -d tvcentras
+            echo "=== Status ==="
+            docker compose ps tvcentras
+          '
 
-      - name: Ensure DNS record for tv.beerpub.dev
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-        run: |
-          if [[ -z "${CF_API_TOKEN}" ]]; then
-            echo "CF_API_TOKEN not set, skipping DNS provisioning"
-            exit 0
-          fi
-
-          ZONE_ID="99dd7fb187fb6f0d08127a7899b92bed"
-          VPS_IP="91.99.74.36"
-
-          # The zone has a *.beerpub.dev wildcard → CF tunnel, so we need an
-          # explicit unproxied A record to override it (same pattern as
-          # table.beerpub.dev and chimney.beerpub.dev).
-          # Find any existing A record for tv.beerpub.dev and get its id/proxied state.
-          record=$(curl -sf \
-            -H "Authorization: Bearer ${CF_API_TOKEN}" \
-            "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=tv.beerpub.dev" \
-            | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-r=d.get('result',[])
-if r: print(r[0]['id'], r[0]['proxied'], r[0]['content'])
-")
-
-          if [[ -z "${record}" ]]; then
-            # No A record — create unproxied one
-            curl -sf -X POST \
-              -H "Authorization: Bearer ${CF_API_TOKEN}" \
-              -H "Content-Type: application/json" \
-              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
-              --data "{\"type\":\"A\",\"name\":\"tv\",\"content\":\"${VPS_IP}\",\"ttl\":1,\"proxied\":false}"
-            echo "DNS record created: tv.beerpub.dev → ${VPS_IP} (unproxied)"
-          else
-            REC_ID=$(echo "${record}" | awk '{print $1}')
-            REC_PROXIED=$(echo "${record}" | awk '{print $2}')
-            REC_IP=$(echo "${record}" | awk '{print $3}')
-            if [[ "${REC_PROXIED}" == "True" || "${REC_IP}" != "${VPS_IP}" ]]; then
-              # Wrong IP or proxied — update to unproxied direct
-              curl -sf -X PUT \
-                -H "Authorization: Bearer ${CF_API_TOKEN}" \
-                -H "Content-Type: application/json" \
-                "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${REC_ID}" \
-                --data "{\"type\":\"A\",\"name\":\"tv\",\"content\":\"${VPS_IP}\",\"ttl\":1,\"proxied\":false}"
-              echo "DNS record updated: tv.beerpub.dev → ${VPS_IP} (unproxied)"
-            else
-              echo "DNS record OK: tv.beerpub.dev → ${VPS_IP} (unproxied)"
-            fi
-          fi
-
-      - name: Ensure Caddy routes tv.beerpub.dev
-        run: |
-          ssh -i ${{ env.SSH_KEY_PATH }} -o StrictHostKeyChecking=no \
-            root@${{ secrets.VPS_HOST }} '
-              CADDYFILE=/opt/coroot/Caddyfile
-              if ! grep -q "tv.beerpub.dev" "$CADDYFILE"; then
-                printf "\n\ntv.beerpub.dev {\n    reverse_proxy tvcentras:8080\n}\n" >> "$CADDYFILE"
-                docker compose -f /opt/coroot/docker-compose.yml exec -T caddy \
-                  caddy reload --config /etc/caddy/Caddyfile
-                echo "Caddy updated with tv.beerpub.dev"
-              else
-                echo "Caddy already has tv.beerpub.dev entry"
-              fi
-            '
-
-      - name: Health check
+      - name: Health check via edge
         run: |
           sleep 5
           curl -sf --retry 5 --retry-delay 3 https://tv.beerpub.dev/health \
             && echo "Health check passed" \
-            || echo "Warning: health check failed"
+            || echo "::warning::Health check failed"
 
       - name: Deployment summary
         if: success()
         run: |
-          echo "### Deployed Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployed to origin" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| URL | https://tv.beerpub.dev |" >> $GITHUB_STEP_SUMMARY
+          echo "| Origin | \`${{ secrets.TVCENTRAS_ORIGIN_IP }}\` (wgmesh, nbg1) |" >> $GITHUB_STEP_SUMMARY
           echo "| Image | \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Digest | \`${{ needs.build-push.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
 
-      - name: Cleanup SSH
+      - name: Cleanup SSH key
         if: always()
-        run: rm -f ${{ env.SSH_KEY_PATH }}
+        run: rm -f ${{ env.SSH_KEY_PATH }} || true

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,0 +1,406 @@
+name: Provision tvcentras origin
+
+# One-shot workflow: creates the Hetzner origin server, joins it to the
+# wgmesh, configures edge Caddy to route tv.beerpub.dev, and updates DNS.
+#
+# After provision, deploys run via deploy.yml (pull + restart over SSH).
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action"
+        required: true
+        type: choice
+        options:
+          - provision
+          - teardown
+          - status
+
+env:
+  HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+  SSH_KEY_PATH: /tmp/tvcentras_ssh
+  SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+jobs:
+  run:
+    name: "Infra: ${{ inputs.action }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      secrets: write   # needed to store TVCENTRAS_ORIGIN_IP
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install hcloud CLI
+        run: |
+          curl -sL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin hcloud
+          hcloud version
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.CHIMNEY_SSH_KEY }}" > ${{ env.SSH_KEY_PATH }}
+          chmod 600 ${{ env.SSH_KEY_PATH }}
+
+      # ──────────────── PROVISION ────────────────
+      - name: Provision tvcentras-origin
+        if: inputs.action == 'provision'
+        run: |
+          set -euo pipefail
+
+          if hcloud server describe tvcentras-origin &>/dev/null; then
+            IP=$(hcloud server ip tvcentras-origin)
+            echo "tvcentras-origin already exists: $IP"
+            echo "ORIGIN_IP=$IP" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          PUB_KEY="${{ secrets.CHIMNEY_SSH_PUBKEY }}"
+
+          # Minimal cloud-init: SSH key + Docker install.
+          # Files are pushed via SCP after server is reachable.
+          cat > /tmp/cloud-init.yaml <<YAML
+#cloud-config
+
+write_files:
+  - path: /root/.ssh/authorized_keys
+    content: |
+      ${PUB_KEY}
+    permissions: '0600'
+    owner: root:root
+  - path: /etc/ssh/sshd_config.d/90-tvcentras.conf
+    content: |
+      PermitRootLogin yes
+      AuthorizedKeysFile .ssh/authorized_keys
+    permissions: '0644'
+
+runcmd:
+  - mkdir -p /root/.ssh && chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys
+  - systemctl restart sshd
+  - curl -fsSL https://get.docker.com | sh
+  - systemctl enable --now docker
+YAML
+
+          hcloud server create \
+            --name tvcentras-origin \
+            --type cax11 \
+            --image ubuntu-24.04 \
+            --location nbg1 \
+            --user-data-from-file /tmp/cloud-init.yaml \
+            --label service=tvcentras \
+            --label role=origin \
+            --label arch=arm64
+
+          IP=$(hcloud server ip tvcentras-origin)
+          echo "Created tvcentras-origin: $IP"
+          echo "ORIGIN_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Wait for SSH
+        if: inputs.action == 'provision'
+        run: |
+          IP="${{ env.ORIGIN_IP }}"
+          echo "Waiting for SSH on $IP..."
+          for i in $(seq 1 30); do
+            if ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} \
+               -o ConnectTimeout=5 root@$IP echo ok 2>/dev/null | grep -q ok; then
+              echo "SSH ready after $((i * 10))s"
+              break
+            fi
+            [ $i -eq 30 ] && { echo "SSH timeout"; exit 1; }
+            echo "Attempt $i/30..."
+            sleep 10
+          done
+
+      - name: Bootstrap origin
+        if: inputs.action == 'provision'
+        run: |
+          IP="${{ env.ORIGIN_IP }}"
+          SCP="scp ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+          SSH="ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+
+          $SCP deploy/origin/compose.yml root@$IP:/tmp/compose.yml
+          $SCP deploy/origin/Caddyfile   root@$IP:/tmp/Caddyfile
+          $SCP deploy/origin/setup.sh    root@$IP:/tmp/setup.sh
+
+          $SSH root@$IP \
+            "WGMESH_SECRET='${{ secrets.WGMESH_SECRET }}' bash /tmp/setup.sh \
+             > /var/log/tvcentras-setup.log 2>&1" && echo "Bootstrap OK"
+
+      - name: Wait for wgmesh and get WireGuard IP
+        if: inputs.action == 'provision'
+        run: |
+          IP="${{ env.ORIGIN_IP }}"
+          echo "Waiting for wg0 interface (up to 5 min)..."
+          for i in $(seq 1 20); do
+            WG_IP=$(ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} root@$IP \
+              "ip -4 addr show wg0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1" \
+              2>/dev/null || echo "")
+            if [ -n "$WG_IP" ]; then
+              echo "WireGuard IP: $WG_IP"
+              echo "WG_IP=$WG_IP" >> "$GITHUB_ENV"
+              break
+            fi
+            echo "Waiting for mesh convergence ($i/20)..."
+            sleep 15
+          done
+          if [ -z "${WG_IP:-}" ]; then
+            echo "::error::wgmesh did not converge in time"
+            ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} root@$IP \
+              "docker compose -f /opt/tvcentras/compose.yml logs wgmesh 2>&1 | tail -20" || true
+            exit 1
+          fi
+
+      - name: Push tv.beerpub.dev block to edge Caddy servers
+        if: inputs.action == 'provision'
+        run: |
+          WG_IP="${{ env.WG_IP }}"
+          SSH="ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+          SCP="scp ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+
+          # Write the Caddy site block with the actual WireGuard IP
+          cat > /tmp/tv-caddy-block.txt <<BLOCK
+
+tv.beerpub.dev {
+    encode gzip
+
+    log {
+        output stderr
+        format console
+        level INFO
+    }
+
+    tls {
+        protocols tls1.2 tls1.3
+    }
+
+    reverse_proxy {
+        to http://${WG_IP}:80
+
+        health_uri /health
+        health_interval 10s
+        health_timeout 5s
+        health_status 200
+
+        lb_policy round_robin
+
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Real-IP {remote_host}
+    }
+
+    header {
+        X-Served-By {system.hostname}
+        -Server
+    }
+}
+BLOCK
+
+          EDGES=$(hcloud server list -l "service=chimney,role=edge" \
+            -o noheader -o columns=name,ipv4 2>/dev/null)
+
+          if [ -z "$EDGES" ]; then
+            echo "::warning::No chimney edge servers found via Hetzner labels"
+            exit 0
+          fi
+
+          while read -r name ip; do
+            [ -z "$name" ] && continue
+            echo "=== Edge: $name ($ip) ==="
+
+            if $SSH root@$ip 'grep -q "tv.beerpub.dev" /opt/chimney/Caddyfile.edge 2>/dev/null'; then
+              echo "tv.beerpub.dev block already present — skipping"
+              continue
+            fi
+
+            $SCP /tmp/tv-caddy-block.txt root@$ip:/tmp/tv-caddy-block.txt
+            $SSH root@$ip 'cat /tmp/tv-caddy-block.txt >> /opt/chimney/Caddyfile.edge'
+
+            # Reload Caddy (bind-mounted file, just need a reload signal)
+            CADDY_ID=$($SSH root@$ip 'docker ps -qf "name=chimney-caddy" | head -1' 2>/dev/null || echo "")
+            if [ -n "$CADDY_ID" ]; then
+              $SSH root@$ip "docker exec $CADDY_ID caddy reload --config /etc/caddy/Caddyfile"
+              echo "Caddy reloaded on $name"
+            else
+              echo "::warning::Caddy container not found on $name"
+            fi
+          done <<< "$EDGES"
+
+      - name: Update DNS — tv.beerpub.dev → edge IPs
+        if: inputs.action == 'provision'
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          ZONE_ID="99dd7fb187fb6f0d08127a7899b92bed"
+
+          # Remove old direct record pointing to the table VPS
+          OLD=$(curl -sf \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=tv.beerpub.dev" \
+            | python3 -c "
+import sys,json
+for r in json.load(sys.stdin).get('result',[]):
+    if r['content'] == '91.99.74.36':
+        print(r['id'])
+" || echo "")
+
+          if [ -n "$OLD" ]; then
+            curl -sf -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${OLD}"
+            echo "Removed A record → 91.99.74.36 (table VPS)"
+          fi
+
+          # Add unproxied A record for each edge server IP
+          EDGE_IPS=$(hcloud server list -l "service=chimney,role=edge" \
+            -o noheader -o columns=ipv4 2>/dev/null)
+
+          for ip in $EDGE_IPS; do
+            existing=$(curl -sf \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=tv.beerpub.dev" \
+              | python3 -c "
+import sys,json
+rs=[r for r in json.load(sys.stdin).get('result',[]) if r['content']=='$ip']
+print(len(rs))" || echo 0)
+
+            if [ "$existing" = "0" ]; then
+              curl -sf -X POST \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                -H "Content-Type: application/json" \
+                "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+                --data "{\"type\":\"A\",\"name\":\"tv\",\"content\":\"${ip}\",\"ttl\":1,\"proxied\":false}"
+              echo "DNS: tv.beerpub.dev → $ip (unproxied)"
+            else
+              echo "DNS: tv.beerpub.dev → $ip already exists"
+            fi
+          done
+
+      - name: Store origin IP as repo secret
+        if: inputs.action == 'provision'
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          IP="${{ env.ORIGIN_IP }}"
+          printf '%s' "$IP" | gh secret set TVCENTRAS_ORIGIN_IP \
+            --repo atvirokodosprendimai/tvcentras
+          echo "TVCENTRAS_ORIGIN_IP=$IP stored as repo secret"
+
+      - name: Clean up old table VPS deployment
+        if: inputs.action == 'provision'
+        run: |
+          VPS="91.99.74.36"
+          SSH="ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+
+          echo "Removing tvcentras from table VPS..."
+          $SSH root@$VPS '
+            set -e
+            cd /opt/tvcentras 2>/dev/null || exit 0
+
+            docker compose down 2>/dev/null || true
+
+            # Remove Caddy entry
+            if grep -q "tv.beerpub.dev" /opt/coroot/Caddyfile 2>/dev/null; then
+              # Remove the tv.beerpub.dev block (3 lines)
+              sed -i "/tv.beerpub.dev/,/^}/d" /opt/coroot/Caddyfile
+              docker compose -f /opt/coroot/docker-compose.yml exec -T caddy \
+                caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || true
+              echo "Caddyfile cleaned on table VPS"
+            fi
+          ' && echo "Table VPS cleanup done" || echo "::warning::Table VPS cleanup failed (may not be reachable)"
+
+      - name: Health check
+        if: inputs.action == 'provision'
+        run: |
+          echo "Waiting 30s for edge TLS cert to issue..."
+          sleep 30
+          curl -sf --retry 6 --retry-delay 10 https://tv.beerpub.dev/health \
+            && echo "tv.beerpub.dev is live via edge" \
+            || echo "::warning::Health check failed — TLS cert may still be issuing"
+
+      - name: Provision summary
+        if: inputs.action == 'provision' && success()
+        run: |
+          echo "### tvcentras origin provisioned" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Origin server | tvcentras-origin (nbg1, cax11, arm64) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Origin IP | \`${{ env.ORIGIN_IP }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| WireGuard IP | \`${{ env.WG_IP }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dashboard | https://tv.beerpub.dev |" >> $GITHUB_STEP_SUMMARY
+
+      # ──────────────── STATUS ────────────────
+      - name: Status
+        if: inputs.action == 'status'
+        run: |
+          echo "## tvcentras Fleet" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          hcloud server list -l "service=tvcentras" \
+            -o columns=name,status,ipv4,datacenter,labels >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          hcloud server list -l "service=tvcentras" -o columns=name,status,ipv4,datacenter
+
+          IP=$(hcloud server ip tvcentras-origin 2>/dev/null || echo "")
+          if [ -n "$IP" ]; then
+            if ssh ${{ env.SSH_OPTS }} -o ConnectTimeout=5 \
+               -i ${{ env.SSH_KEY_PATH }} root@$IP echo ok 2>/dev/null | grep -q ok; then
+              echo "SSH: OK"
+              ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} root@$IP \
+                'docker compose -f /opt/tvcentras/compose.yml ps 2>/dev/null || true'
+            fi
+          fi
+
+      # ──────────────── TEARDOWN ────────────────
+      - name: Teardown
+        if: inputs.action == 'teardown'
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          ZONE_ID="99dd7fb187fb6f0d08127a7899b92bed"
+          SSH="ssh ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }}"
+
+          # Remove tv.beerpub.dev from edge Caddy
+          EDGES=$(hcloud server list -l "service=chimney,role=edge" \
+            -o noheader -o columns=name,ipv4 2>/dev/null) || true
+          while read -r name ip; do
+            [ -z "$name" ] && continue
+            echo "Cleaning edge $name..."
+            $SSH root@$ip '
+              sed -i "/^tv\.beerpub\.dev/,/^}/d" /opt/chimney/Caddyfile.edge 2>/dev/null || true
+              CADDY_ID=$(docker ps -qf "name=chimney-caddy" | head -1)
+              [ -n "$CADDY_ID" ] && docker exec $CADDY_ID caddy reload --config /etc/caddy/Caddyfile || true
+            ' || true
+          done <<< "$EDGES"
+
+          # Remove DNS records pointing to edge IPs
+          EDGE_IPS=$(hcloud server list -l "service=chimney,role=edge" \
+            -o noheader -o columns=ipv4 2>/dev/null) || true
+          for ip in $EDGE_IPS; do
+            REC_ID=$(curl -sf \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A&name=tv.beerpub.dev" \
+              | python3 -c "
+import sys,json
+for r in json.load(sys.stdin).get('result',[]):
+    if r['content']=='$ip': print(r['id'])
+" || echo "")
+            [ -n "$REC_ID" ] && curl -sf -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${REC_ID}" \
+              && echo "Removed DNS: tv.beerpub.dev → $ip" || true
+          done
+
+          # Delete origin server
+          if hcloud server describe tvcentras-origin &>/dev/null; then
+            hcloud server delete tvcentras-origin
+            echo "tvcentras-origin deleted"
+          fi
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ${{ env.SSH_KEY_PATH }} || true

--- a/deploy/origin/Caddyfile
+++ b/deploy/origin/Caddyfile
@@ -1,0 +1,22 @@
+# Origin Caddyfile for tvcentras.
+#
+# auto_https off: origins are only reached from edge Caddy via WireGuard
+# (plain HTTP on :80). TLS terminates on the edges, not here.
+# Enabling auto_https would cause 308 redirects that break edge health checks.
+
+{
+    admin localhost:2019
+    auto_https off
+}
+
+:80 {
+    encode gzip
+
+    log {
+        output stderr
+        format console
+        level INFO
+    }
+
+    reverse_proxy localhost:8080
+}

--- a/deploy/origin/compose.yml
+++ b/deploy/origin/compose.yml
@@ -1,0 +1,59 @@
+# tvcentras origin server
+#
+# Three services:
+#   wgmesh    — joins the shared WireGuard mesh (host network, NET_ADMIN)
+#   tvcentras — Go dashboard, bound to localhost:8080 only
+#   caddy     — HTTP-only reverse proxy (host network, auto_https off)
+#               listens on :80 of all interfaces including the WG IP,
+#               so edge Caddy can reach it over the mesh
+#
+# Pattern mirrors chimney origin: app on 127.0.0.1 port, Caddy on host
+# network proxies to it. TLS lives on the edge servers only.
+
+name: tvcentras
+
+volumes:
+  caddy_data:
+  caddy_config:
+  wgmesh_state:
+
+services:
+
+  wgmesh:
+    image: ghcr.io/atvirokodosprendimai/wgmesh:latest
+    restart: unless-stopped
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    volumes:
+      - wgmesh_state:/var/lib/wgmesh
+      - /lib/modules:/lib/modules:ro
+    environment:
+      WGMESH_SECRET: ${WGMESH_SECRET:-}
+    command:
+      - join
+      - --secret=${WGMESH_SECRET:-}
+
+  tvcentras:
+    image: ghcr.io/atvirokodosprendimai/tvcentras:latest
+    restart: always
+    pull_policy: always
+    ports:
+      - "127.0.0.1:8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - tvcentras

--- a/deploy/origin/setup.sh
+++ b/deploy/origin/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Bootstrap tvcentras origin server. Idempotent — safe to re-run.
+# Expects: WGMESH_SECRET exported in environment.
+# Files expected in /tmp: compose.yml, Caddyfile
+set -euo pipefail
+
+DEPLOY_DIR="/opt/tvcentras"
+
+echo "=== tvcentras origin setup ==="
+
+# ── Docker ──
+if ! command -v docker &>/dev/null; then
+    echo "Installing Docker..."
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable docker
+    systemctl start docker
+    echo "Docker: $(docker --version)"
+else
+    echo "Docker: $(docker --version)"
+fi
+
+# ── Deploy directory ──
+mkdir -p "$DEPLOY_DIR"
+
+# ── Copy files ──
+cp /tmp/compose.yml  "$DEPLOY_DIR/compose.yml"
+cp /tmp/Caddyfile    "$DEPLOY_DIR/Caddyfile"
+
+# ── Write .env ──
+cat > "$DEPLOY_DIR/.env" <<EOF
+WGMESH_SECRET=${WGMESH_SECRET:-}
+EOF
+chmod 600 "$DEPLOY_DIR/.env"
+
+# ── Pull images ──
+echo "Pulling images..."
+docker compose \
+    -f "$DEPLOY_DIR/compose.yml" \
+    --project-directory "$DEPLOY_DIR" \
+    --env-file "$DEPLOY_DIR/.env" \
+    pull --quiet 2>/dev/null || true
+
+# ── Start stack ──
+echo "Starting tvcentras stack..."
+docker compose \
+    -f "$DEPLOY_DIR/compose.yml" \
+    --project-directory "$DEPLOY_DIR" \
+    --env-file "$DEPLOY_DIR/.env" \
+    up -d
+
+echo ""
+echo "=== setup complete ==="
+docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" ps


### PR DESCRIPTION
## Summary
- Provisions a dedicated Hetzner `cax11` arm64 server (`tvcentras-origin`) that joins the existing wgmesh network
- Edge Caddy (chimney-hel1/ash) routes `tv.beerpub.dev` → origin WireGuard IP over HTTP; TLS terminates at the edge
- Removes all direct-to-VPS deployment logic from `deploy.yml`

## New files
- `deploy/origin/compose.yml` — wgmesh + tvcentras + Caddy (HTTP-only) stack
- `deploy/origin/Caddyfile` — `auto_https off`, `:80 → localhost:8080`
- `deploy/origin/setup.sh` — idempotent bootstrap (Docker install + stack start)
- `.github/workflows/provision.yml` — one-shot provision/teardown/status workflow

## Updated files
- `.github/workflows/deploy.yml` — SSH to `TVCENTRAS_ORIGIN_IP` via `CHIMNEY_SSH_KEY`

## Pre-requisites
Secrets needed in this repo (copy from wgmesh via [PR #337](https://github.com/atvirokodosprendimai/wgmesh/pull/337)):
- `HCLOUD_TOKEN`
- `WGMESH_SECRET`
- `CHIMNEY_SSH_KEY`
- `CHIMNEY_SSH_PUBKEY`

## Test plan
- [ ] Merge wgmesh PR #337 → run copy-secrets workflow → verify secrets in this repo
- [ ] Merge this PR
- [ ] Run **Provision tvcentras origin** (action: `provision`) → server created, joins mesh, edge Caddy updated
- [ ] Trigger **Deploy TV Dashboard** workflow → deploys to origin
- [ ] Verify https://tv.beerpub.dev/health returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)